### PR TITLE
feat: Yearly Goals Kanban board

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -29,6 +29,7 @@ const TABS = {
   TRANSACTIONS: 'Transactions',
   CONFIG:       'Config',
   PROJECTS:     'Projects',     // Multi-step projects with Claude-generated subtasks
+  GOALS:        'Goals',        // Yearly goals Kanban board
   PTO:          'PTO',          // PTO planner snapshot (written nightly by writePTOSnapshot_)
   PTO_MEMORY:   'PTO Memory',   // Stateful PTO suggestion history (declined windows blacklist)
 };
@@ -41,6 +42,7 @@ const METRIC_HEADERS      = ['Source', 'Metric', 'Value', 'As Of'];  // Metrics 
 const SUMMARY_HEADERS     = ['Source', 'Metric', 'Value', 'As Of'];  // Summaries tab
 const TRANSACTION_HEADERS = ['Date', 'Account', 'Description', 'Category', 'Tags', 'Amount'];
 const CONFIG_HEADERS      = ['Setting', 'Value'];
+const GOAL_HEADERS        = ['ID', 'Title', 'Description', 'Status', 'Category', 'Year', 'Progress', 'Notes'];
 const PTO_HEADERS         = ['Type', 'Label', 'Start Date', 'End Date', 'Weekdays', 'Hours', 'Status'];
 const PTO_MEMORY_HEADERS  = ['Start Date', 'End Date', 'Workdays', 'GCal Event ID', 'Status', 'Suggested On'];
 
@@ -89,6 +91,7 @@ function createSheetTabs(ss) {
   ensureSheet(ss, TABS.SUMMARIES,    SUMMARY_HEADERS);
   ensureSheet(ss, TABS.TRANSACTIONS, TRANSACTION_HEADERS);
   ensureSheet(ss, TABS.PROJECTS,     PROJECT_HEADERS);
+  ensureSheet(ss, TABS.GOALS,        GOAL_HEADERS);
   ensureSheet(ss, TABS.PTO,          PTO_HEADERS);
   ensureSheet(ss, TABS.PTO_MEMORY,   PTO_MEMORY_HEADERS);
   ensureSheet(ss, TABS.CONFIG,       CONFIG_HEADERS, configDefaults);

--- a/Goals.js
+++ b/Goals.js
@@ -1,0 +1,200 @@
+// ============================================================
+// VERA — Goals.js
+// CRUD operations for the Goals tab (Yearly Goals Kanban)
+// ============================================================
+
+const GOAL_COL = {
+  ID:          0,
+  TITLE:       1,
+  DESCRIPTION: 2,
+  STATUS:      3,
+  CATEGORY:    4,
+  YEAR:        5,
+  PROGRESS:    6,
+  NOTES:       7,
+};
+
+const GOAL_STATUSES = ['Resolutions', 'To Do', 'Doing', 'Parked', 'Done'];
+
+// ============================================================
+// READ
+// ============================================================
+
+/**
+ * Returns all goal rows as an array of objects.
+ * Skips blank rows.
+ */
+function getGoals_() {
+  const ss    = getSpreadsheet();
+  const sheet = ss.getSheetByName(TABS.GOALS);
+  if (!sheet || sheet.getLastRow() < 2) return [];
+
+  const numRows = sheet.getLastRow() - 1;
+  const data    = sheet.getRange(2, 1, numRows, GOAL_HEADERS.length).getValues();
+
+  return data
+    .map(function(row, i) { return { row: i + 2, data: row }; })
+    .filter(function(r) { return String(r.data[GOAL_COL.ID] || '').trim() !== ''; })
+    .map(function(r) {
+      const row = r.data;
+      return {
+        id:          String(row[GOAL_COL.ID]          || ''),
+        title:       String(row[GOAL_COL.TITLE]       || ''),
+        description: String(row[GOAL_COL.DESCRIPTION] || ''),
+        status:      String(row[GOAL_COL.STATUS]      || 'To Do'),
+        category:    String(row[GOAL_COL.CATEGORY]    || ''),
+        year:        row[GOAL_COL.YEAR] ? Number(row[GOAL_COL.YEAR]) : new Date().getFullYear(),
+        progress:    row[GOAL_COL.PROGRESS] !== '' ? Number(row[GOAL_COL.PROGRESS]) : 0,
+        notes:       String(row[GOAL_COL.NOTES]       || ''),
+        rowNum:      r.row,
+      };
+    });
+}
+
+// ============================================================
+// CREATE
+// ============================================================
+
+/**
+ * Appends a new goal row and returns the created goal object.
+ */
+function createGoal_(title, description, status, category, year, notes) {
+  if (!title || title.trim() === '') throw new Error('Goal title is required.');
+
+  const ss    = getSpreadsheet();
+  const sheet = ss.getSheetByName(TABS.GOALS);
+  if (!sheet) throw new Error('Goals tab not found. Run setupVERA() first.');
+
+  const tz        = Session.getScriptTimeZone();
+  const dateStr   = Utilities.formatDate(new Date(), tz, 'yyyyMMdd');
+  const lastRow   = sheet.getLastRow();
+  const seqNum    = Math.max(1, lastRow); // simple incrementing suffix
+  const id        = 'GOAL-' + dateStr + '-' + String(seqNum).padStart(2, '0');
+  const goalYear  = year ? Number(year) : new Date().getFullYear();
+  const goalStatus = GOAL_STATUSES.indexOf(status) !== -1 ? status : 'To Do';
+
+  const row = [
+    id,
+    String(title       || '').trim(),
+    String(description || '').trim(),
+    goalStatus,
+    String(category    || '').trim(),
+    goalYear,
+    0,  // progress starts at 0
+    String(notes       || '').trim(),
+  ];
+
+  sheet.appendRow(row);
+  Logger.log('createGoal_: created ' + id + ' — ' + title);
+
+  return {
+    id:          id,
+    title:       row[GOAL_COL.TITLE],
+    description: row[GOAL_COL.DESCRIPTION],
+    status:      row[GOAL_COL.STATUS],
+    category:    row[GOAL_COL.CATEGORY],
+    year:        goalYear,
+    progress:    0,
+    notes:       row[GOAL_COL.NOTES],
+    rowNum:      sheet.getLastRow(),
+  };
+}
+
+// ============================================================
+// UPDATE
+// ============================================================
+
+/**
+ * Updates one or more fields of a goal identified by ID.
+ * Only fields present in the `fields` object are written.
+ * Returns the updated goal object, or null if not found.
+ */
+function updateGoal_(id, fields) {
+  if (!id) throw new Error('Goal ID is required.');
+
+  const ss    = getSpreadsheet();
+  const sheet = ss.getSheetByName(TABS.GOALS);
+  if (!sheet || sheet.getLastRow() < 2) return null;
+
+  const numRows = sheet.getLastRow() - 1;
+  const data    = sheet.getRange(2, 1, numRows, GOAL_HEADERS.length).getValues();
+
+  let targetRow = -1;
+  for (var i = 0; i < data.length; i++) {
+    if (String(data[i][GOAL_COL.ID]).trim() === String(id).trim()) {
+      targetRow = i + 2; // 1-indexed + header
+      break;
+    }
+  }
+
+  if (targetRow === -1) {
+    Logger.log('updateGoal_: ID not found — ' + id);
+    return null;
+  }
+
+  const colMap = {
+    title:       GOAL_COL.TITLE       + 1,
+    description: GOAL_COL.DESCRIPTION + 1,
+    status:      GOAL_COL.STATUS      + 1,
+    category:    GOAL_COL.CATEGORY    + 1,
+    year:        GOAL_COL.YEAR        + 1,
+    progress:    GOAL_COL.PROGRESS    + 1,
+    notes:       GOAL_COL.NOTES       + 1,
+  };
+
+  Object.keys(fields).forEach(function(key) {
+    if (colMap[key]) {
+      let val = fields[key];
+      if (key === 'status' && GOAL_STATUSES.indexOf(val) === -1) return;
+      if (key === 'progress') val = Math.min(100, Math.max(0, Number(val) || 0));
+      if (key === 'year')     val = Number(val) || new Date().getFullYear();
+      sheet.getRange(targetRow, colMap[key]).setValue(val);
+    }
+  });
+
+  Logger.log('updateGoal_: updated ' + id + ' — ' + JSON.stringify(fields));
+
+  // Re-read and return updated row
+  const updated = sheet.getRange(targetRow, 1, 1, GOAL_HEADERS.length).getValues()[0];
+  return {
+    id:          String(updated[GOAL_COL.ID]),
+    title:       String(updated[GOAL_COL.TITLE]),
+    description: String(updated[GOAL_COL.DESCRIPTION]),
+    status:      String(updated[GOAL_COL.STATUS]),
+    category:    String(updated[GOAL_COL.CATEGORY]),
+    year:        Number(updated[GOAL_COL.YEAR]) || new Date().getFullYear(),
+    progress:    Number(updated[GOAL_COL.PROGRESS]) || 0,
+    notes:       String(updated[GOAL_COL.NOTES]),
+    rowNum:      targetRow,
+  };
+}
+
+// ============================================================
+// DELETE
+// ============================================================
+
+/**
+ * Deletes the row for the given goal ID.
+ * Returns true if found and deleted, false if not found.
+ */
+function deleteGoal_(id) {
+  if (!id) throw new Error('Goal ID is required.');
+
+  const ss    = getSpreadsheet();
+  const sheet = ss.getSheetByName(TABS.GOALS);
+  if (!sheet || sheet.getLastRow() < 2) return false;
+
+  const numRows = sheet.getLastRow() - 1;
+  const data    = sheet.getRange(2, 1, numRows, 1).getValues();
+
+  for (var i = 0; i < data.length; i++) {
+    if (String(data[i][0]).trim() === String(id).trim()) {
+      sheet.deleteRow(i + 2);
+      Logger.log('deleteGoal_: deleted ' + id);
+      return true;
+    }
+  }
+
+  Logger.log('deleteGoal_: ID not found — ' + id);
+  return false;
+}

--- a/WebApp.js
+++ b/WebApp.js
@@ -81,6 +81,10 @@ function doGet(e) {
       case 'add_project_task':      return jsonOut_(webAddProjectTask_(e));
       case 'update_project_task':   return jsonOut_(webUpdateProjectTask_(e));
       case 'delete_project_task':   return jsonOut_(webDeleteProjectTask_(e));
+      case 'goals':        return jsonOut_(webGetGoals_());
+      case 'add_goal':    return jsonOut_(webAddGoal_(e));
+      case 'update_goal': return jsonOut_(webUpdateGoal_(e));
+      case 'delete_goal': return jsonOut_(webDeleteGoal_(e));
       case 'pto':                   return jsonOut_(webGetPTO_());
       case 'pto_trigger_buffer':    return jsonOut_(webTriggerBuffer_(e));
       case 'chat':                  return jsonOut_(webProcessChat_(e));
@@ -514,6 +518,48 @@ function webProcessChat_(e) {
 // ============================================================
 // UTILITIES
 // ============================================================
+
+// ---- Goals (Yearly Goals Kanban) -------------------------------------------
+
+function webGetGoals_() {
+  const goals = getGoals_();
+  return { ok: true, count: goals.length, goals: goals };
+}
+
+function webAddGoal_(e) {
+  const p = e.parameter || {};
+  const goal = createGoal_(
+    p.title || '',
+    p.description || '',
+    p.status || 'To Do',
+    p.category || '',
+    p.year || '',
+    p.notes || ''
+  );
+  return { ok: true, goal: goal };
+}
+
+function webUpdateGoal_(e) {
+  const p  = e.parameter || {};
+  const id = (p.id || '').trim();
+  if (!id) throw new Error('Goal ID is required');
+
+  const fields = {};
+  ['title', 'description', 'status', 'category', 'year', 'progress', 'notes'].forEach(function(k) {
+    if (p[k] != null) fields[k] = p[k];
+  });
+
+  const updated = updateGoal_(id, fields);
+  if (!updated) return { ok: false, error: 'Goal not found: ' + id };
+  return { ok: true, goal: updated };
+}
+
+function webDeleteGoal_(e) {
+  const id = ((e.parameter && e.parameter.id) || '').trim();
+  if (!id) throw new Error('Goal ID is required');
+  const deleted = deleteGoal_(id);
+  return { ok: deleted, id: id, action: 'deleted' };
+}
 
 function formatDateVal_(val) {
   if (!val || val === '') return '';

--- a/docs/index.html
+++ b/docs/index.html
@@ -492,6 +492,89 @@
     }
     .btn-edit:hover { color: #c9a84c; background: #13244d; }
 
+    /* ---- Yearly Goals Kanban ---- */
+    .kanban-board {
+      display: flex;
+      gap: 12px;
+      overflow-x: auto;
+      padding-bottom: 12px;
+      align-items: flex-start;
+    }
+    .kanban-col {
+      flex: 0 0 220px;
+      background: #0d1b3e;
+      border-radius: 10px;
+      padding: 12px;
+      border: 2px solid #1e3a6e;
+      transition: border-color 0.15s;
+    }
+    .kanban-col.drag-over { border-color: #c9a84c; }
+    .kanban-col-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 10px;
+    }
+    .kanban-col-title {
+      font-size: 13px;
+      font-weight: 700;
+      color: #c9a84c;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+    }
+    .kanban-col-count {
+      font-size: 11px;
+      background: #1e3a6e;
+      color: #8ab4f8;
+      border-radius: 10px;
+      padding: 2px 7px;
+    }
+    .kanban-add-btn {
+      width: 100%;
+      background: none;
+      border: 1px dashed #2a4580;
+      border-radius: 6px;
+      color: #4d6080;
+      font-size: 12px;
+      padding: 6px;
+      cursor: pointer;
+      margin-top: 8px;
+      transition: border-color 0.15s, color 0.15s;
+    }
+    .kanban-add-btn:hover { border-color: #c9a84c; color: #c9a84c; }
+    .goal-card {
+      background: #1a2744;
+      border: 1px solid #2a4580;
+      border-radius: 8px;
+      padding: 10px;
+      margin-bottom: 8px;
+      cursor: grab;
+      user-select: none;
+      transition: opacity 0.15s, box-shadow 0.15s;
+    }
+    .goal-card:active { cursor: grabbing; }
+    .goal-card.dragging { opacity: 0.4; }
+    .goal-card-title { font-size: 13px; color: #e0e8f8; font-weight: 600; margin-bottom: 6px; line-height: 1.3; }
+    .goal-card-meta { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 6px; }
+    .goal-cat-pill {
+      font-size: 10px;
+      background: #0d1b3e;
+      border: 1px solid #2a4580;
+      border-radius: 10px;
+      padding: 1px 7px;
+      color: #8ab4f8;
+    }
+    .goal-year-badge { font-size: 10px; color: #4d6080; }
+    .goal-progress-bar {
+      height: 4px;
+      background: #1e3a6e;
+      border-radius: 2px;
+      margin-bottom: 6px;
+      overflow: hidden;
+    }
+    .goal-progress-fill { height: 100%; background: #c9a84c; border-radius: 2px; transition: width 0.3s; }
+    .goal-card-actions { display: flex; gap: 6px; justify-content: flex-end; }
+
     /* ---- PTO tab ---- */
     .pto-grid-2 {
       display: grid;
@@ -1273,6 +1356,132 @@ function AddItemModal({ stores, onSave, onClose, busy }) {
   );
 }
 
+// ---- Yearly Goals Kanban tab ------------------------------------------------
+
+const GOAL_STATUSES = ['Resolutions', 'To Do', 'Doing', 'Parked', 'Done'];
+const GOAL_COL_COLORS = {
+  'Resolutions': '#7c5cbf',
+  'To Do':       '#1565c0',
+  'Doing':       '#c9a84c',
+  'Parked':      '#4d6080',
+  'Done':        '#43a047',
+};
+
+function GoalsTab({ goals, dragGoalId, dragOverCol, onDragStart, onDragOver, onDrop, onAddGoal, onEditGoal, onDeleteGoal, busy }) {
+  return (
+    <div>
+      <div style={{ marginBottom: 14, color: '#8ab4f8', fontSize: 13 }}>
+        Drag goal cards between columns to update their status.
+      </div>
+      <div className="kanban-board">
+        {GOAL_STATUSES.map(col => {
+          const colGoals = goals.filter(g => g.status === col);
+          const isOver   = dragOverCol === col;
+          return (
+            <div
+              key={col}
+              className={`kanban-col${isOver ? ' drag-over' : ''}`}
+              onDragOver={e => { e.preventDefault(); onDragOver(col); }}
+              onDrop={e => { e.preventDefault(); onDrop(col); }}
+              onDragLeave={() => { if (dragOverCol === col) onDragOver(null); }}
+            >
+              <div className="kanban-col-header">
+                <span className="kanban-col-title" style={{ color: GOAL_COL_COLORS[col] }}>{col}</span>
+                <span className="kanban-col-count">{colGoals.length}</span>
+              </div>
+
+              {colGoals.map(goal => (
+                <div
+                  key={goal.id}
+                  className={`goal-card${dragGoalId === goal.id ? ' dragging' : ''}`}
+                  draggable
+                  onDragStart={() => onDragStart(goal.id)}
+                  onDragEnd={() => { onDragStart(null); onDragOver(null); }}
+                >
+                  <div className="goal-card-title">{goal.title}</div>
+                  <div className="goal-card-meta">
+                    {goal.category && <span className="goal-cat-pill">{goal.category}</span>}
+                    <span className="goal-year-badge">{goal.year}</span>
+                  </div>
+                  {goal.progress > 0 && (
+                    <div className="goal-progress-bar">
+                      <div className="goal-progress-fill" style={{ width: goal.progress + '%' }} />
+                    </div>
+                  )}
+                  <div className="goal-card-actions">
+                    <button className="btn-edit" title="Edit" disabled={busy} onClick={() => onEditGoal(goal)}>✏️</button>
+                    <button className="btn-edit" title="Delete" disabled={busy} onClick={() => onDeleteGoal(goal.id)} style={{ color: '#e53935' }}>🗑</button>
+                  </div>
+                </div>
+              ))}
+
+              <button className="kanban-add-btn" onClick={() => onAddGoal(col)}>+ Add goal</button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function GoalModal({ mode, goal, defaultStatus, onSave, onClose, busy }) {
+  const [title,       setTitle]       = React.useState(goal?.title       || '');
+  const [description, setDescription] = React.useState(goal?.description || '');
+  const [status,      setStatus]      = React.useState(goal?.status      || defaultStatus || 'To Do');
+  const [category,    setCategory]    = React.useState(goal?.category    || '');
+  const [year,        setYear]        = React.useState(goal?.year        || new Date().getFullYear());
+  const [progress,    setProgress]    = React.useState(goal?.progress    ?? 0);
+  const [notes,       setNotes]       = React.useState(goal?.notes       || '');
+
+  return (
+    <div className="modal-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <div className="modal" style={{ maxWidth: 420 }}>
+        <h2>{mode === 'edit' ? 'Edit Goal' : 'Add Goal'}</h2>
+        <label className="form-label">Title *</label>
+        <input className="form-input" value={title} onChange={e => setTitle(e.target.value)} placeholder="Goal title" autoFocus />
+
+        <label className="form-label">Description</label>
+        <textarea className="form-input" rows={2} value={description} onChange={e => setDescription(e.target.value)} placeholder="Optional detail" style={{ resize: 'vertical' }} />
+
+        <label className="form-label">Status</label>
+        <select className="form-input" value={status} onChange={e => setStatus(e.target.value)}>
+          {GOAL_STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
+        </select>
+
+        <div style={{ display: 'flex', gap: 10 }}>
+          <div style={{ flex: 1 }}>
+            <label className="form-label">Category</label>
+            <input className="form-input" value={category} onChange={e => setCategory(e.target.value)} placeholder="e.g. Health" />
+          </div>
+          <div style={{ width: 80 }}>
+            <label className="form-label">Year</label>
+            <input className="form-input" type="number" value={year} onChange={e => setYear(e.target.value)} />
+          </div>
+        </div>
+
+        {mode === 'edit' && (
+          <>
+            <label className="form-label">Progress ({progress}%)</label>
+            <input type="range" min="0" max="100" value={progress} onChange={e => setProgress(Number(e.target.value))}
+              style={{ width: '100%', accentColor: '#c9a84c', marginBottom: 12 }} />
+          </>
+        )}
+
+        <label className="form-label">Notes</label>
+        <textarea className="form-input" rows={2} value={notes} onChange={e => setNotes(e.target.value)} placeholder="Optional notes" style={{ resize: 'vertical' }} />
+
+        <div className="modal-actions">
+          <button className="btn" onClick={onClose}>Cancel</button>
+          <button className="btn btn-primary" disabled={!title.trim() || busy}
+            onClick={() => onSave({ title, description, status, category, year, progress, notes })}>
+            {mode === 'edit' ? 'Save Changes' : 'Add Goal'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ---- Projects tab -----------------------------------------------------------
 
 const PRIORITY_COLORS = { High: '#e53935', Medium: '#f9a825', Low: '#43a047' };
@@ -1908,6 +2117,7 @@ function App() {
   const [tasks,      setTasks]      = useState([]);
   const [summaries,  setSummaries]  = useState([]);
   const [projects,   setProjects]   = useState([]);
+  const [goals,      setGoals]      = useState([]);
   const [shopping,   setShopping]   = useState([]);
   const [pto,        setPTO]        = useState(null);
   const [chatMessages, setChatMessages] = useState([{ role: 'vera', text: VERA_CHAT_WELCOME }]);
@@ -1917,6 +2127,9 @@ function App() {
   const [completingIds, setCompletingIds] = useState({});
   const [taskModal,        setTaskModal]        = useState(null); // null | { mode:'add' } | { mode:'edit', task }
   const [projectTaskModal, setProjectTaskModal] = useState(null); // null | { mode:'add', project } | { mode:'edit', task }
+  const [goalModal,        setGoalModal]        = useState(null); // null | { mode:'add', status? } | { mode:'edit', goal }
+  const [dragGoalId,       setDragGoalId]       = useState(null);
+  const [dragOverCol,      setDragOverCol]      = useState(null);
   const toastTimer = useRef(null);
 
   const loadAll = useCallback(async (url, token, activeOnly) => {
@@ -1955,6 +2168,7 @@ function App() {
   useEffect(() => {
     if (apiUrl && apiToken) {
       loadProjects(apiUrl, apiToken);
+      loadGoals(apiUrl, apiToken);
       loadShopping(apiUrl, apiToken);
       loadPTO(apiUrl, apiToken);
     }
@@ -2026,6 +2240,18 @@ function App() {
       setError(err.message);
     }
     setTabLoading(prev => ({ ...prev, projects: false }));
+  }
+
+  async function loadGoals(url, token) {
+    if (!url || !token) return;
+    setTabLoading(prev => ({ ...prev, goals: true }));
+    try {
+      const data = await apiGet(url, token, { action: 'goals' });
+      setGoals(data.goals || []);
+    } catch (err) {
+      setError(err.message);
+    }
+    setTabLoading(prev => ({ ...prev, goals: false }));
   }
 
   async function loadShopping(url, token) {
@@ -2166,12 +2392,37 @@ function App() {
     setBusy(false);
   }
 
+  async function handleSaveGoal({ title, description, status, category, year, progress, notes }) {
+    if (!title.trim()) return;
+    setBusy(true);
+    try {
+      if (goalModal.mode === 'edit') {
+        await apiGet(apiUrl, apiToken, {
+          action: 'update_goal', id: goalModal.goal.id,
+          title, description, status, category, year, progress, notes,
+        });
+        showToast('✓ Goal updated');
+      } else {
+        await apiGet(apiUrl, apiToken, {
+          action: 'add_goal', title, description, status, category, year, notes,
+        });
+        showToast('✓ Goal added');
+      }
+      setGoalModal(null);
+      loadGoals(apiUrl, apiToken);
+    } catch (err) {
+      setError('Could not save goal: ' + err.message);
+    }
+    setBusy(false);
+  }
+
   function handleConnect(url, token) {
     setApiUrl(url);
     setApiToken(token);
     setShowSettings(false);
     loadAll(url, token, filterActive);
     loadProjects(url, token);
+    loadGoals(url, token);
     loadShopping(url, token);
     loadPTO(url, token);
   }
@@ -2263,13 +2514,14 @@ function App() {
           <StatusBar status={status} loading={loading} />
 
           <div className="tabs">
-            {['home', 'chat', 'flags', 'tasks', 'projects', 'shopping', 'pto', 'summaries'].map(tab => (
+            {['home', 'chat', 'flags', 'tasks', 'projects', 'goals', 'shopping', 'pto', 'summaries'].map(tab => (
               <button
                 key={tab}
                 className={`tab-btn ${activeTab === tab ? 'active' : ''}`}
                 onClick={() => {
                   setActiveTab(tab);
                   if (tab === 'projects') loadProjects(apiUrl, apiToken);
+                  if (tab === 'goals')    loadGoals(apiUrl, apiToken);
                   if (tab === 'shopping') loadShopping(apiUrl, apiToken);
                   if (tab === 'pto')      loadPTO(apiUrl, apiToken);
                 }}
@@ -2279,6 +2531,7 @@ function App() {
                 {tab === 'flags'    ? `🚩 Flags${status ? ` (${status.activeFlags})` : ''}` : ''}
                 {tab === 'tasks'    ? `✅ Tasks${tasks.length ? ` (${tasks.length})` : ''}` : ''}
                 {tab === 'projects' ? `📂 Projects${projects.length ? ` (${projects.length})` : ''}` : ''}
+                {tab === 'goals'    ? `🎯 Yearly Goals${goals.length ? ` (${goals.length})` : ''}` : ''}
                 {tab === 'shopping' ? `🛒 Shopping` : ''}
                 {tab === 'pto'      ? `🌴 PTO Planner` : ''}
                 {tab === 'summaries'? `📊 Summaries` : ''}
@@ -2403,6 +2656,46 @@ function App() {
                   />
             )}
 
+            {/* Yearly Goals tab */}
+            {activeTab === 'goals' && (
+              tabLoading.goals
+                ? <div className="loading-text">Loading goals…</div>
+                : <GoalsTab
+                    goals={goals}
+                    dragGoalId={dragGoalId}
+                    dragOverCol={dragOverCol}
+                    onDragStart={id => setDragGoalId(id)}
+                    onDragOver={col => setDragOverCol(col)}
+                    onDrop={async (newStatus) => {
+                      if (!dragGoalId || !newStatus) { setDragGoalId(null); setDragOverCol(null); return; }
+                      const id = dragGoalId;
+                      setDragGoalId(null);
+                      setDragOverCol(null);
+                      // Optimistic update
+                      setGoals(prev => prev.map(g => g.id === id ? { ...g, status: newStatus } : g));
+                      try {
+                        await apiGet(apiUrl, apiToken, { action: 'update_goal', id, status: newStatus });
+                      } catch (err) {
+                        setError('Failed to move goal: ' + err.message);
+                        loadGoals(apiUrl, apiToken);
+                      }
+                    }}
+                    onAddGoal={status => setGoalModal({ mode: 'add', status: status || 'To Do' })}
+                    onEditGoal={g => setGoalModal({ mode: 'edit', goal: g })}
+                    onDeleteGoal={async (id) => {
+                      if (!window.confirm('Delete this goal?')) return;
+                      setGoals(prev => prev.filter(g => g.id !== id));
+                      try {
+                        await apiGet(apiUrl, apiToken, { action: 'delete_goal', id });
+                      } catch (err) {
+                        setError('Failed to delete goal: ' + err.message);
+                        loadGoals(apiUrl, apiToken);
+                      }
+                    }}
+                    busy={busy}
+                  />
+            )}
+
             {/* Shopping tab */}
             {activeTab === 'shopping' && (
               tabLoading.shopping
@@ -2427,6 +2720,18 @@ function App() {
             )}
           </div>
         </>
+      )}
+
+      {/* Goal modal */}
+      {goalModal && (
+        <GoalModal
+          mode={goalModal.mode}
+          goal={goalModal.goal}
+          defaultStatus={goalModal.status}
+          onSave={handleSaveGoal}
+          onClose={() => setGoalModal(null)}
+          busy={busy}
+        />
       )}
 
       {/* Toast notification */}


### PR DESCRIPTION
## Summary
- Closes #37
- New **Goals.js** backend with full CRUD: `getGoals_()`, `createGoal_()`, `updateGoal_()`, `deleteGoal_()`
- New **Goals** sheet tab — created automatically by `setupVERA()` / `createSheetTabs()`; columns: ID, Title, Description, Status, Category, Year, Progress, Notes
- **WebApp.js**: 4 new GET endpoints (`goals`, `add_goal`, `update_goal`, `delete_goal`)
- **Dashboard**: "🎯 Yearly Goals" nav tab with a drag-and-drop Kanban board

## Kanban columns (left → right)
| Column | Purpose |
|--------|---------|
| Resolutions | Aspirational / not yet committed |
| To Do | Committed, not started |
| Doing | In progress |
| Parked | On hold |
| Done | Complete |

## Drag-and-drop
- Drag any goal card to a different column → status updates immediately (optimistic UI) and persists to the sheet via `update_goal`
- Visual feedback: column border highlights gold on hover, card dims while dragging

## Goal card fields
- Title, optional category pill, year badge, progress bar (when > 0%)
- ✏️ Edit button → opens modal with all fields including a progress % slider
- 🗑 Delete button → confirms then removes

## Test plan
- [ ] Run `createSheetTabs()` (or `setupVERA()`) → confirm "Goals" tab created with correct headers
- [ ] Hit `?action=add_goal&title=Test&status=To+Do&token=...` → row appears in sheet
- [ ] Hit `?action=goals&token=...` → returns JSON array
- [ ] Open dashboard → 🎯 Yearly Goals tab shows 5 columns
- [ ] Drag a card to a different column → status updates in sheet
- [ ] Add a new goal via "+ Add goal" button, edit it, delete it

🤖 Generated with [Claude Code](https://claude.com/claude-code)